### PR TITLE
set NODE_ENV to production when build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "A light foundation for your next frontend project based on webpack.",
   "scripts": {
-    "build": "webpack --config webpack/webpack.config.prod.js  --colors",
+    "build": "NODE_ENV=production webpack --config webpack/webpack.config.prod.js  --colors",
     "start": "webpack-dev-server --open --config webpack/webpack.config.dev.js"
   },
   "repository": {


### PR DESCRIPTION
Thanks for your great project! I find it very useful!

When building this project I find the need to set `NODE_ENV` to production. For instance if a package like [autoprefixer](https://github.com/postcss/autoprefixer) reads `.browserslistrc`, it will not get the correct environment. So adding it would be beneficial in most cases.