### PR TITLE
Update webpack.config.prod.js

### DIFF
--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -16,7 +16,6 @@ module.exports = merge(common, {
     new Webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
     }),
-    new Webpack.optimize.ModuleConcatenationPlugin(),
     new MiniCssExtractPlugin({
       filename: 'bundle.css',
     }),


### PR DESCRIPTION
Since webpack 4, `ModuleConcatenationPlugin` is deprecated and  can be removed from configuration as they are default in production mode: https://webpack.js.org/migrate/4/#deprecatedremoved-plugins and https://webpack.js.org/configuration/optimization/#optimizationconcatenatemodules